### PR TITLE
Allow build for LP and fix second ramdisk creation

### DIFF
--- a/lib/Android.mk
+++ b/lib/Android.mk
@@ -98,16 +98,18 @@ LOCAL_ARM_MODE := arm
 LOCAL_SRC_FILES:= \
     src/base/ftbbox.c \
     src/base/ftbitmap.c \
+    src/base/ftfntfmt.c \
     src/base/ftfstype.c \
     src/base/ftglyph.c \
     src/base/ftlcdfil.c \
     src/base/ftstroke.c \
     src/base/fttype1.c \
-    src/base/ftxf86.c \
     src/base/ftbase.c \
     src/base/ftsystem.c \
     src/base/ftinit.c \
     src/base/ftgasp.c \
+    src/base/ftmm.c \
+    src/gzip/ftgzip.c \
     src/raster/raster.c \
     src/sfnt/sfnt.c \
     src/smooth/smooth.c \

--- a/lib/Android.mk
+++ b/lib/Android.mk
@@ -98,7 +98,6 @@ LOCAL_ARM_MODE := arm
 LOCAL_SRC_FILES:= \
     src/base/ftbbox.c \
     src/base/ftbitmap.c \
-    src/base/ftfntfmt.c \
     src/base/ftfstype.c \
     src/base/ftglyph.c \
     src/base/ftlcdfil.c \

--- a/lib/inject.c
+++ b/lib/inject.c
@@ -36,7 +36,7 @@
 #endif
 
 #define TMP_RD_UNPACKED_DIR "/mrom_rd"
-#define TMP_RD2_UNPACKED_DIR TMP_RD_UNPACKED_DIR"/sbin"
+#define TMP_RD2_UNPACKED_DIR TMP_RD_UNPACKED_DIR"/second"
 #define TMP_RD2 TMP_RD2_UNPACKED_DIR"/ramdisk.cpio"
 
 static int get_img_trampoline_ver(struct bootimg *img)


### PR DESCRIPTION
The first two changes allow multirom to build again on LP 5.1 android platforms (updated freetype lib).

The second modification corrects the path for the second ramdisk. The original implementation cannot work, as the second ramdisk is created within the second temporary directory which is deleted directly after ramdisk creation. Examining the created bootimage proofs that the ramdisk is missing before the proposed change, whereas the bootimage looks correct after applying the patch.
