### PR TITLE
arm64: add more logging for loading dtb.img and exclude more places

### DIFF
--- a/multirom.c
+++ b/multirom.c
@@ -2168,12 +2168,16 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
     kexec_add_arg(kexec, "--initrd=/initrd.img");
 
 #ifdef MR_KEXEC_DTB
-    if(libbootimg_dump_dtb(&img, "/dtb.img") >= 0)
+    if(libbootimg_dump_dtb(&img, "/dtb.img") >= 0) {
+        printf("DTB: dtb image found!");
         kexec_add_arg(kexec, "--dtb=/dtb.img");
+    }
+    else {
+        printf("DTB: no dtb image found!");
 #ifdef MR_NOT_64BIT
-    else
         kexec_add_arg(kexec, "--dtb");
 #endif
+    }
 #endif
 
     char cmdline[1536];
@@ -2333,11 +2337,15 @@ int multirom_fill_kexec_linux(struct multirom_status *s, struct multirom_rom *ro
     }
     else
     {
+        printf("DTB: dtb image found!");
         str = find_boot_file("%r/dtb.img", root_path, rom->base_path);
     }
 
     if(!str)
+        printf("DTB: no dtb image found!");
+#ifdef MR_NOT_64BIT
         kexec_add_arg(kexec, "--dtb");
+#endif
     else
     {
         kexec_add_arg_prefix(kexec, "--dtb=", str);


### PR DESCRIPTION
where --dtb is passed with no parameter.

this causes arm64 kexec to error out.
