### PR TITLE
Add support for loading different MRom binaries

### DIFF
--- a/install_zip/Android.mk
+++ b/install_zip/Android.mk
@@ -45,7 +45,7 @@ $(MULTIROM_ZIP_TARGET): multirom trampoline signapk bbootimg mrom_kexec_static m
 	rm -rf $(MULTIROM_INST_DIR)
 	mkdir -p $(MULTIROM_INST_DIR)
 	cp -a $(install_zip_path)/prebuilt-installer/* $(MULTIROM_INST_DIR)/
-	cp -a $(TARGET_ROOT_OUT)/multirom $(MULTIROM_INST_DIR)/multirom/
+	cp -a $(TARGET_ROOT_OUT)/multirom* $(MULTIROM_INST_DIR)/multirom/
 	cp -a $(TARGET_ROOT_OUT)/trampoline $(MULTIROM_INST_DIR)/multirom/
 	cp -a $(TARGET_OUT_OPTIONAL_EXECUTABLES)/mrom_kexec_static $(MULTIROM_INST_DIR)/multirom/kexec
 	cp -a $(TARGET_OUT_OPTIONAL_EXECUTABLES)/mrom_adbd $(MULTIROM_INST_DIR)/multirom/adbd

--- a/trampoline/Android.mk
+++ b/trampoline/Android.mk
@@ -50,6 +50,11 @@ else
 endif
 endif
 
+ifneq ($(MR_BINARY_SELECTOR),)
+    LOCAL_CFLAGS += -DMR_USE_BINARY_SELECTOR=1
+    LOCAL_SRC_FILES += ../../../../$(MR_BINARY_SELECTOR)
+endif
+
 ifeq ($(MR_ENCRYPTION),true)
     LOCAL_CFLAGS += -DMR_ENCRYPTION
     LOCAL_SRC_FILES += encryption.c

--- a/trampoline/multirom_binary_selector.h
+++ b/trampoline/multirom_binary_selector.h
@@ -1,0 +1,6 @@
+#ifndef LIB_TRAMPOLINE_BINARY_SELECTION_H_
+#define LIB_TRAMPOLINE_BINARY_SELECTION_H_
+
+int get_mutirom_binary_string(char *binary_name);
+
+#endif /* LIB_TRAMPOLINE_BINARY_SELECTION_H_ */

--- a/trampoline/trampoline.c
+++ b/trampoline/trampoline.c
@@ -37,7 +37,11 @@
 #include "encryption.h"
 
 #ifdef MR_POPULATE_BY_NAME_PATH
-	#include "Populate_ByName_using_emmc.c"
+#include "Populate_ByName_using_emmc.c"
+#endif
+
+#ifdef MR_USE_BINARY_SELECTOR
+#include "multirom_binary_selector.h"
 #endif
 
 #define EXEC_MASK (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
@@ -77,6 +81,7 @@ static void run_multirom(void)
 {
     char path[256];
     struct stat info;
+    char multirom_bin[256] = MULTIROM_BIN;
 
     // busybox
     sprintf(path, "%s/%s", path_multirom, BUSYBOX_BIN);
@@ -91,8 +96,18 @@ static void run_multirom(void)
     sprintf(path, "%s/restart_after_crash", path_multirom);
     int restart = (stat(path, &info) >= 0);
 
+#ifdef MR_USE_BINARY_SELECTOR
+    if (get_mutirom_binary_string(multirom_bin) == -1)
+    {
+        strcpy(multirom_bin, MULTIROM_BIN);
+    }
+
+    // ensure null termination of multirom name string
+    multirom_bin[255] = '\0';
+#endif
+
     // multirom
-    sprintf(path, "%s/%s", path_multirom, MULTIROM_BIN);
+    sprintf(path, "%s/%s", path_multirom, &multirom_bin);
     if (stat(path, &info) < 0)
     {
         ERROR("Could not find multirom: %s\n", path);


### PR DESCRIPTION
This commit allows to load different multirom binaries from trampoline.
It is enabled by defining MR_BINARY_SELECTOR in a device's Makefile
which points a C source file from the android root directory. In this
file, the function get_multirom_binary_string must be implemented which
writes a string to the passed parameter that is the name of the multirom
binary to load.
Any implementation must follow these conventions:
- On an error, or if the default binary ("multirom") shall be loaded, -1
  must be returned.
- The name of the multirom binary may not exceed 255 chars.

The reasoning behind this change is that incompatible changes between
different kernel versions may occur which require multirom binaries to
be compiled for these specific kernel/android versions. Since the main
distribution path via the multirom app does not allow to deliver
different multirom zip files, runtime dispatching is required.

This case has been observed for the Z2 (or similar devices) when
switching from the 1.2.2 to the 1.3.3 AOSP kernel that included a change
in the display driver. This caused a crash in multirom if the binary was
compiled for the other kernel that was not the primary one of the
device.

Change-Id: I76df9e0ac022b5e7d62259e7fac41c3951451ebc
Signed-off-by: Alexander Diewald Diewi@diewald-net.com
