### PR TITLE
Revert "multirom: trampoline: Add support for loading different MRom …

### DIFF
--- a/install_zip/Android.mk
+++ b/install_zip/Android.mk
@@ -45,7 +45,7 @@ $(MULTIROM_ZIP_TARGET): multirom trampoline signapk bbootimg mrom_kexec_static m
 	rm -rf $(MULTIROM_INST_DIR)
 	mkdir -p $(MULTIROM_INST_DIR)
 	cp -a $(install_zip_path)/prebuilt-installer/* $(MULTIROM_INST_DIR)/
-	cp -a $(TARGET_ROOT_OUT)/multirom* $(MULTIROM_INST_DIR)/multirom/
+	cp -a $(TARGET_ROOT_OUT)/multirom $(MULTIROM_INST_DIR)/multirom/
 	cp -a $(TARGET_ROOT_OUT)/trampoline $(MULTIROM_INST_DIR)/multirom/
 	cp -a $(TARGET_OUT_OPTIONAL_EXECUTABLES)/mrom_kexec_static $(MULTIROM_INST_DIR)/multirom/kexec
 	cp -a $(TARGET_OUT_OPTIONAL_EXECUTABLES)/mrom_adbd $(MULTIROM_INST_DIR)/multirom/adbd

--- a/trampoline/Android.mk
+++ b/trampoline/Android.mk
@@ -50,11 +50,6 @@ else
 endif
 endif
 
-ifneq ($(MR_BINARY_SELECTOR),)
-    LOCAL_CFLAGS += -DMR_USE_BINARY_SELECTOR=1
-    LOCAL_SRC_FILES += ../../../../$(MR_BINARY_SELECTOR)
-endif
-
 ifeq ($(MR_ENCRYPTION),true)
     LOCAL_CFLAGS += -DMR_ENCRYPTION
     LOCAL_SRC_FILES += encryption.c

--- a/trampoline/multirom_binary_selector.h
+++ b/trampoline/multirom_binary_selector.h
@@ -1,6 +1,0 @@
-#ifndef LIB_TRAMPOLINE_BINARY_SELECTION_H_
-#define LIB_TRAMPOLINE_BINARY_SELECTION_H_
-
-int get_mutirom_binary_string(char *binary_name);
-
-#endif /* LIB_TRAMPOLINE_BINARY_SELECTION_H_ */

--- a/trampoline/trampoline.c
+++ b/trampoline/trampoline.c
@@ -37,11 +37,7 @@
 #include "encryption.h"
 
 #ifdef MR_POPULATE_BY_NAME_PATH
-#include "Populate_ByName_using_emmc.c"
-#endif
-
-#ifdef MR_USE_BINARY_SELECTOR
-#include "multirom_binary_selector.h"
+	#include "Populate_ByName_using_emmc.c"
 #endif
 
 #define EXEC_MASK (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
@@ -81,7 +77,6 @@ static void run_multirom(void)
 {
     char path[256];
     struct stat info;
-    char multirom_bin[256] = MULTIROM_BIN;
 
     // busybox
     sprintf(path, "%s/%s", path_multirom, BUSYBOX_BIN);
@@ -96,18 +91,8 @@ static void run_multirom(void)
     sprintf(path, "%s/restart_after_crash", path_multirom);
     int restart = (stat(path, &info) >= 0);
 
-#ifdef MR_USE_BINARY_SELECTOR
-    if (get_mutirom_binary_string(multirom_bin) == -1)
-    {
-        strcpy(multirom_bin, MULTIROM_BIN);
-    }
-
-    // ensure null termination of multirom name string
-    multirom_bin[255] = '\0';
-#endif
-
     // multirom
-    sprintf(path, "%s/%s", path_multirom, &multirom_bin);
+    sprintf(path, "%s/%s", path_multirom, MULTIROM_BIN);
     if (stat(path, &info) < 0)
     {
         ERROR("Could not find multirom: %s\n", path);


### PR DESCRIPTION
…binaries"

No longer needed since Sony AOSP kernel version 1.2.2 is very outdated
now. Stock & 1.3.3-based kernels work fine without. This feature was
used for Sony Shinano-based devices only.

This reverts commit ff18745b30ac89ae41d5021147e686d2d33e9d86.