### PR TITLE
Force build system to use C11.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -25,7 +25,7 @@ LOCAL_SRC_FILES:= \
 
 # With these, GCC optimizes aggressively enough so full-screen alpha blending
 # is quick enough to be done in an animation
-LOCAL_CFLAGS += -O3 -funsafe-math-optimizations
+LOCAL_CFLAGS += -O3 -funsafe-math-optimizations -std=c11
 
 #LOCAL_CFLAGS += -D_FORTIFY_SOURCE=2 -fstack-protector-all -O0 -g -fno-omit-frame-pointer -Wall
 


### PR DESCRIPTION
Depending on the system. Building of multirom might fail due to wrong C version being used and giving us error:
"error: 'for' loop initial declarations are only allowed in C99 or C11 mode".
This commit will force the build system to use C11 standard instead of system default which might be wrong in some cases. 